### PR TITLE
Add a .gitignore file to ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
The .DS_Store file saves custom attributes of a folder on a macOS. We don't need this file in the repository.